### PR TITLE
feat: 会話スレッドへの返信機能 (reply_to_thread) の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ Cursorなどのエディタと統合することで、「PRの未解決コメン
 }
 ```
 
+### 3. `reply_to_thread`
+指定されたプルリクエストの会話スレッドに返信コメントを追加します。
+
+**パラメータ:**
+- `threadId`: GraphQL Node ID (例: `PRRT_...`)
+- `body`: 返信するコメントの本文
+
+**返り値:**
+```json
+{
+  "success": true,
+  "commentUrl": "https://github.com/..."
+}
+```
+
 ## セットアップ
 
 ### 1. インストール
@@ -72,6 +87,7 @@ npm run build
 GitHub Personal Access Tokenが必要です。操作ごとに必要なスコープは以下の通りです：
 - `get_unresolved_threads`（未解決スレッドの取得）: パブリックリポジトリの場合は `read:repo` または `repo:status`。プライベートリポジトリの場合は `repo` スコープが必要です。
 - `resolve_conversation`（スレッドの解決）: `repo`（リポジトリへのフルアクセス）が必要です
+- `reply_to_thread`（スレッドへの返信）: `repo`（リポジトリへのフルアクセス）が必要です
 
 より限定的な権限で運用したい場合は、パブリックリポジトリの読み取り専用操作には `read:repo` などを利用できます。プライベートリポジトリや両方の操作を行う場合は `repo` スコープが必要です。
 トークンは環境変数 `GITHUB_TOKEN` として設定します。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-github-resolver",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for resolving GitHub PR conversations",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## 概要
Issue #3 の対応として、特定のスレッドに対して返信コメントを投稿する `reply_to_thread` ツールを追加しました。

## 変更点
- `src/index.ts`:
  - `reply_to_thread` ツールの定義を追加
  - GraphQL Mutation `AddReply` の実装
  - `ReplyToThreadSchema` と `AddReplyResponse` 型定義の追加
- `README.md`:
  - 新機能 `reply_to_thread` のドキュメントを追加
- `package.json`:
  - バージョンを `1.1.0` に更新

## 動作確認
`reply_to_thread` を使用して、指定したスレッドに返信が投稿されることを確認しました。

Resolves #3