### PR TITLE
fix: resolve linter errors and add explicit types for tool handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "mcp-github-resolver",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-github-resolver",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.4",
+        "@modelcontextprotocol/sdk": "^1.22.0",
         "@octokit/graphql": "^8.1.1",
         "dotenv": "^16.4.5",
         "zod": "^3.23.8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,17 +206,20 @@ async function graphqlRequest<T>(
 }
 
 // ツール: 未解決スレッドの取得
+const getUnresolvedThreadsSchema = z.object({
+  owner: z.string().describe("リポジトリオーナー"),
+  repo: z.string().describe("リポジトリ名"),
+  pullRequestNumber: z.number().describe("プルリクエスト番号"),
+});
+
 server.registerTool(
   "get_unresolved_threads",
   {
     description: "指定したプルリクエストの未解決の会話スレッド一覧を取得します",
-    inputSchema: z.object({
-      owner: z.string().describe("リポジトリオーナー"),
-      repo: z.string().describe("リポジトリ名"),
-      pullRequestNumber: z.number().describe("プルリクエスト番号"),
-    }),
+    inputSchema: getUnresolvedThreadsSchema,
   },
-  async ({ owner, repo, pullRequestNumber }) => {
+  async (args: z.infer<typeof getUnresolvedThreadsSchema>) => {
+    const { owner, repo, pullRequestNumber } = args;
     const response = await graphqlRequest<GetUnresolvedThreadsResponse>(
       GET_UNRESOLVED_THREADS_QUERY,
       {
@@ -269,15 +272,18 @@ server.registerTool(
 );
 
 // ツール: スレッドの解決
+const resolveConversationSchema = z.object({
+  threadId: z.string().describe("スレッドID (GraphQL Node ID)"),
+});
+
 server.registerTool(
   "resolve_conversation",
   {
     description: "特定のスレッドIDを指定して会話を解決済みにします",
-    inputSchema: z.object({
-      threadId: z.string().describe("スレッドID (GraphQL Node ID)"),
-    }),
+    inputSchema: resolveConversationSchema,
   },
-  async ({ threadId }) => {
+  async (args: z.infer<typeof resolveConversationSchema>) => {
+    const { threadId } = args;
     const response = await graphqlRequest<ResolveThreadResponse>(
       RESOLVE_THREAD_MUTATION,
       {
@@ -305,16 +311,19 @@ server.registerTool(
 );
 
 // ツール: スレッドへの返信
+const replyToThreadSchema = z.object({
+  threadId: z.string().describe("スレッドID (GraphQL Node ID)"),
+  body: z.string().describe("返信するコメントの本文"),
+});
+
 server.registerTool(
   "reply_to_thread",
   {
     description: "指定されたプルリクエストの会話スレッドに返信コメントを追加します",
-    inputSchema: z.object({
-      threadId: z.string().describe("スレッドID (GraphQL Node ID)"),
-      body: z.string().describe("返信するコメントの本文"),
-    }),
+    inputSchema: replyToThreadSchema,
   },
-  async ({ threadId, body }) => {
+  async (args: z.infer<typeof replyToThreadSchema>) => {
+    const { threadId, body } = args;
     const response = await graphqlRequest<AddReplyResponse>(
       ADD_REPLY_MUTATION,
       {


### PR DESCRIPTION
- Run npm install to restore node_modules (fixes module/process resolution)
- Extract input schemas for get_unresolved_threads, resolve_conversation, reply_to_thread
- Type tool handlers with z.infer<typeof schema> to remove implicit any